### PR TITLE
support json attributes

### DIFF
--- a/go/web/main.js
+++ b/go/web/main.js
@@ -1,4 +1,3 @@
-"use strict";
 (() => {
   var __defProp = Object.defineProperty;
   var __getOwnPropSymbols = Object.getOwnPropertySymbols;
@@ -165,12 +164,18 @@
       if (elem) {
         propertiesUpdate.newAttributes.forEach((kv) => {
           const k = kv.key;
-          const val = kv.value;
+          const val = JSON.parse(kv.value);
           if (SPECIAL_ATTRIBUTES.has(k)) {
             elem[k] = val;
             return;
           }
-          elem.setAttribute(k, val);
+          if (val === true) {
+            elem.setAttribute(k, "");
+          } else if (val === false) {
+            elem.removeAttribute(k);
+          } else {
+            elem.setAttribute(k, val);
+          }
         });
         propertiesUpdate.removedAttributes.forEach((k) => {
           elem.removeAttribute(k);

--- a/web/server.ts
+++ b/web/server.ts
@@ -39,7 +39,7 @@ export function createDocumentServer(peer: Peer): () => void {
     if (elem) {
       propertiesUpdate.newAttributes.forEach(kv => {
         const k = kv.key;
-        const val = kv.value;
+        const val = JSON.parse(kv.value);
 
         if (SPECIAL_ATTRIBUTES.has(k)) {
           // @ts-ignore
@@ -47,7 +47,14 @@ export function createDocumentServer(peer: Peer): () => void {
           return;
         }
 
-        elem.setAttribute(k, val);
+        // special handling for booleans attributes
+        if (val === true) {
+          elem.setAttribute(k, '');
+        } else if (val === false) {
+          elem.removeAttribute(k);
+        } else {
+          elem.setAttribute(k, val);
+        }
       })
 
       propertiesUpdate.removedAttributes.forEach(k => {


### PR DESCRIPTION
Serializes all attribute updates as JSON, and handles booleans specially on the client side.

With this change, any JSON-able struct can be used as an attribute, the corresponding client-side value will be the JSON.parse result.

TODO: should add tests.